### PR TITLE
Add service configs for mattermost services

### DIFF
--- a/chat-services/mattermost-github.yaml
+++ b/chat-services/mattermost-github.yaml
@@ -1,0 +1,6 @@
+services:
+- hash: None
+  hash_length: 7
+  name: chat-integrations-github
+  path: /github/openshift/mattermost-github.app.yaml
+  url: https://github.com/rhdt/chat-integrations

--- a/chat-services/mattermost-gitlab.yaml
+++ b/chat-services/mattermost-gitlab.yaml
@@ -1,0 +1,6 @@
+services:
+- hash: None
+  hash_length: 7
+  name: chat-integrations-gitlab
+  path: /gitlab/openshift/mattermost-gitlab.app.yaml
+  url: https://github.com/rhdt/chat-integrations

--- a/chat-services/mattermost-irc.yaml
+++ b/chat-services/mattermost-irc.yaml
@@ -1,0 +1,6 @@
+services:
+- hash: None
+  hash_length: 7
+  name: chat-integrations-irc
+  path: /irc/openshift/mattermost-irc-bridge.app.yaml
+  url: https://github.com/rhdt/chat-integrations

--- a/chat-services/mattermost-rss.yaml
+++ b/chat-services/mattermost-rss.yaml
@@ -1,0 +1,6 @@
+services:
+- hash: None
+  hash_length: 7
+  name: chat-integrations-rss
+  path: /rss/openshift/mattermost-rss.app.yaml
+  url: https://github.com/rhdt/chat-integrations

--- a/chat-services/mattermost.yaml
+++ b/chat-services/mattermost.yaml
@@ -1,0 +1,6 @@
+services:
+- hash: None
+  hash_length: 7
+  name: chat
+  path: /openshift/mattermost.app.yaml
+  url: https://github.com/rhdt/chat


### PR DESCRIPTION
Add the service configs for mattermost that are consumed by the promote-to-prod job.
These link back to the yaml templates that are to be deployed.