### PR TITLE
Fix service names for penfold

### DIFF
--- a/chat-services/mattermost-penfold-app.yaml
+++ b/chat-services/mattermost-penfold-app.yaml
@@ -1,6 +1,6 @@
 services:
 - hash: None
   hash_length: 7
-  name: chat-integrations-gitlab
+  name: penfold-penfold
   path: /penfold/openshift/mattermost-penfold.app.yaml
   url: https://github.com/rhdt/penfold

--- a/chat-services/mattermost-penfold-mongodb.yaml
+++ b/chat-services/mattermost-penfold-mongodb.yaml
@@ -1,6 +1,6 @@
 services:
 - hash: None
   hash_length: 7
-  name: chat-integrations-penfold-mongo
+  name: penfold-mongodb 
   path: /mongodb/openshift/mongodb.app.yaml
   url: https://github.com/rhdt/penfold


### PR DESCRIPTION
rename service names for penfold and its backing mongodb