### PR TITLE
add hash for deploying integrations

### DIFF
--- a/chat-services/mattermost-github.yaml
+++ b/chat-services/mattermost-github.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: None
+- hash: 197c52e79ecc0b1e30b452b836563ff38921077b
   hash_length: 7
   name: chat-integrations-github
   path: /github/openshift/mattermost-github.app.yaml

--- a/chat-services/mattermost-gitlab.yaml
+++ b/chat-services/mattermost-gitlab.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: None
+- hash: 197c52e79ecc0b1e30b452b836563ff38921077b
   hash_length: 7
   name: chat-integrations-gitlab
   path: /gitlab/openshift/mattermost-gitlab.app.yaml

--- a/chat-services/mattermost-irc.yaml
+++ b/chat-services/mattermost-irc.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: None
+- hash: 197c52e79ecc0b1e30b452b836563ff38921077b
   hash_length: 7
   name: chat-integrations-irc
   path: /irc/openshift/mattermost-irc-bridge.app.yaml

--- a/chat-services/mattermost-rss.yaml
+++ b/chat-services/mattermost-rss.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: None
+- hash: 197c52e79ecc0b1e30b452b836563ff38921077b
   hash_length: 7
   name: chat-integrations-rssfeeds
   path: /rssfeeds/openshift/mattermost-rss.app.yaml


### PR DESCRIPTION
adding the hash from https://github.com/rhdt/chat-integrations for deploying IRC, Gitlab, GitHub,RSS integrations